### PR TITLE
Add back link & styling

### DIFF
--- a/src/kibana/plugins/openshift-kibana/controllers/header.js
+++ b/src/kibana/plugins/openshift-kibana/controllers/header.js
@@ -1,0 +1,8 @@
+define(function (require) {
+  var kibana = require('modules').get('kibana');
+  kibana.controller('OSHeaderController', function ($scope, UserStore, $location) {
+    var user = UserStore.getUser();
+    $scope.containerName = user.container_name ? user.container_name : 'Untitled Container';
+    $scope.goBack = user.back_url;
+  });
+});

--- a/src/kibana/plugins/openshift-kibana/directives/kibana.js
+++ b/src/kibana/plugins/openshift-kibana/directives/kibana.js
@@ -1,10 +1,10 @@
 define(function (require) {
-  require(['text!plugins/openshift-kibana/partials/header.html'], function(header){
+  require(['text!plugins/openshift-kibana/partials/header.html'], function (header) {
     var kibana = require('modules').get('kibana');
-    kibana.directive("kibana", function($parse) {
+    kibana.directive('kibana', function ($location, $compile, $parse) {
       return {
-        link: function(scope, element, attrs){
-          element.prepend(header);
+        link: function (scope, element, attrs) {
+          element.prepend($compile(header)(scope));
         }
       };
     });

--- a/src/kibana/plugins/openshift-kibana/index.js
+++ b/src/kibana/plugins/openshift-kibana/index.js
@@ -1,5 +1,6 @@
 define(function (require) {
   require('css!plugins/openshift-kibana/styles/main.css');
+  require('plugins/openshift-kibana/controllers/header');
   require('plugins/openshift-kibana/directives/kibana');
   require('plugins/openshift-kibana/services/logger');
   require('plugins/openshift-kibana/services/userstore');

--- a/src/kibana/plugins/openshift-kibana/partials/header.html
+++ b/src/kibana/plugins/openshift-kibana/partials/header.html
@@ -1,1 +1,4 @@
-<div class='foo'>added it via header</div>
+<div class='container-header' ng-controller="OSHeaderController">
+  <h4>Connected to <span ng-bind="containerName"></span></h4>
+  <a ng-show="goBack" ng-href="{{goBack}}"><i class="fa fa-arrow-left"></i> Back</a>
+</div>

--- a/src/kibana/plugins/openshift-kibana/services/auth.js
+++ b/src/kibana/plugins/openshift-kibana/services/auth.js
@@ -1,19 +1,14 @@
 define(function (require) {
   var plugin = require('modules').get('plugins/openshift-kibana');
   var qs = require('utils/query_string');
-  
   plugin.provider('AuthService', function () {
     this.$get = function ($location, UserStore) {
       return {
         stashToken: function () {
-          var hash = qs.decode($location.hash());
-          var value = hash.openshift_auth_token || false;
-          if (value !== false) {
-            UserStore.setToken(value);
-            delete hash['openshift_auth_token'];
-            delete hash['openshift_back_url'];
-            $location.hash(qs.encode(hash));
-            $location.replace();
+          // TODO just so other code kinda behaves the same
+          var user = UserStore.getUser();
+          if ('auth_token' in user) {
+            UserStore.setToken(user.auth_token);
           }
         },
         setAuthorization: function (config) {
@@ -25,7 +20,6 @@ define(function (require) {
       };
     };
   });
-
   plugin.factory('AuthInterceptor', ['AuthService', function (AuthService) {
     return {
       request: function (config) {

--- a/src/kibana/plugins/openshift-kibana/services/userstore.js
+++ b/src/kibana/plugins/openshift-kibana/services/userstore.js
@@ -1,112 +1,133 @@
 define(function (require) {
   var plugin = require('modules').get('plugins/openshift-kibana');
-
-  
+  var qs = require('utils/query_string');
   //ref: https://github.com/openshift/origin/blob/master/assets/app/scripts/services/userstore.js
-  plugin.provider('LocalStorageUserStore', function() {
-    this.$get = function(Logger){
-      var authLogger = Logger.get("auth");
-      var userkey = "LocalStorageUserStore.user";
-      var tokenkey = "LocalStorageUserStore.token";
-
-      var ttlKey = function(key) {
-        return key + ".ttl";
+  plugin.provider('LocalStorageUserStore', function () {
+    this.$get = function ($location, Logger) {
+      var authLogger = Logger.get('auth');
+      var userkey = 'LocalStorageUserStore.user';
+      var tokenkey = 'LocalStorageUserStore.token';
+      var hash = qs.decode($location.hash());
+      var settings = {};
+      if (userkey in localStorage) {
+        try {
+          settings = JSON.parse(localStorage[userkey]);
+        } catch (e) {
+          // corrupt entry, let's clear it...
+          localStorage.removeItem(userkey);
+        }
+      }
+      var regex = /^openshift_/;
+      var toRemove = [];
+      Object.getOwnPropertyNames(hash).forEach(function (propName) {
+        if (propName.search(regex) !== -1) {
+          var settingName = propName.replace(regex, '');
+          if (settingName.length > 0) {
+            settings[settingName] = hash[propName];
+            toRemove.push(propName);
+          }
+        }
+      });
+      toRemove.forEach(function (propName) {
+        delete hash[propName];
+      });
+      localStorage[userkey] = JSON.stringify(settings);
+      $location.hash(qs.encode(hash));
+      $location.replace();
+      var ttlKey = function (key) {
+        return key + '.ttl';
       };
-      var setTTL = function(key, ttl) {
+      var setTTL = function (key, ttl) {
         if (ttl) {
-          var expires = new Date().getTime() + ttl*1000;
+          var expires = new Date().getTime() + ttl * 1000;
           localStorage[ttlKey(key)] = expires;
-          authLogger.log("LocalStorageUserStore.setTTL", key, ttl, new Date(expires).toString());
+          authLogger.log('LocalStorageUserStore.setTTL', key, ttl, new Date(expires).toString());
         } else {
           localStorage.removeItem(ttlKey(key));
-          authLogger.log("LocalStorageUserStore.setTTL deleting", key);
+          authLogger.log('LocalStorageUserStore.setTTL deleting', key);
         }
       };
-      var isTTLExpired = function(key) {
+      var isTTLExpired = function (key) {
         var ttl = localStorage[ttlKey(key)];
         if (!ttl) {
           return false;
         }
         var expired = parseInt(ttl) < new Date().getTime();
-        authLogger.log("LocalStorageUserStore.isTTLExpired", key, expired);
+        authLogger.log('LocalStorageUserStore.isTTLExpired', key, expired);
         return expired;
       };
-
       return {
-        available: function() {
+        available: function () {
           try {
             var x = String(new Date().getTime());
             localStorage['LocalStorageUserStore.test'] = x;
             var y = localStorage['LocalStorageUserStore.test'];
             localStorage.removeItem('LocalStorageUserStore.test');
             return x === y;
-          } catch(e) {
+          } catch (e) {
             return false;
           }
         },
-        getUser: function(){
+        getUser: function () {
           try {
             if (isTTLExpired(userkey)) {
-              authLogger.log("LocalStorageUserStore.getUser expired");
+              authLogger.log('LocalStorageUserStore.getUser expired');
               localStorage.removeItem(userkey);
               setTTL(userkey, null);
               return null;
             }
             var user = JSON.parse(localStorage[userkey]);
-            authLogger.log("LocalStorageUserStore.getUser", user);
+            authLogger.log('LocalStorageUserStore.getUser', user);
             return user;
-          } catch(e) {
-            authLogger.error("LocalStorageUserStore.getUser", e);
+          } catch (e) {
+            authLogger.error('LocalStorageUserStore.getUser', e);
             return null;
           }
         },
-        setUser: function(user, ttl) {
+        setUser: function (user, ttl) {
           if (user) {
-            authLogger.log("LocalStorageUserStore.setUser", user, ttl);
+            authLogger.log('LocalStorageUserStore.setUser', user, ttl);
             localStorage[userkey] = JSON.stringify(user);
             setTTL(userkey, ttl);
           } else {
-            authLogger.log("LocalStorageUserStore.setUser", user, "deleting");
+            authLogger.log('LocalStorageUserStore.setUser', user, 'deleting');
             localStorage.removeItem(userkey);
             setTTL(userkey, null);
           }
         },
-        getToken: function() {
+        getToken: function () {
           try {
             if (isTTLExpired(tokenkey)) {
-              authLogger.log("LocalStorageUserStore.getToken expired");
+              authLogger.log('LocalStorageUserStore.getToken expired');
               localStorage.removeItem(tokenkey);
               setTTL(tokenkey, null);
               return null;
             }
             var token = localStorage[tokenkey];
-            authLogger.log("LocalStorageUserStore.getToken", token);
+            authLogger.log('LocalStorageUserStore.getToken', token);
             return token;
-          } catch(e) {
-            authLogger.error("LocalStorageUserStore.getToken", e);
+          } catch (e) {
+            authLogger.error('LocalStorageUserStore.getToken', e);
             return null;
           }
         },
-        setToken: function(token, ttl) {
+        setToken: function (token, ttl) {
           if (token) {
-            authLogger.log("LocalStorageUserStore.setToken", token, ttl);
+            authLogger.log('LocalStorageUserStore.setToken', token, ttl);
             localStorage[tokenkey] = token;
             setTTL(tokenkey, ttl);
           } else {
-            authLogger.log("LocalStorageUserStore.setToken", token, ttl, "deleting");
+            authLogger.log('LocalStorageUserStore.setToken', token, ttl, 'deleting');
             localStorage.removeItem(tokenkey);
             setTTL(tokenkey, null);
           }
         }
       };
     };
-
   });
-    
   plugin.provider('UserStore', function () {
     this.$get = function (LocalStorageUserStore) {
       return LocalStorageUserStore;
     };
   });
 });
-

--- a/src/kibana/plugins/openshift-kibana/styles/main.less
+++ b/src/kibana/plugins/openshift-kibana/styles/main.less
@@ -1,12 +1,31 @@
 @import (reference) "../../../styles/main.less";
-
-//#kibana-primary-navbar {
-//  background-color: red;
-//}
-
 .navbar-inverse .logo {
     background-image: url('../images/kibana_on_openshift.png');
     background-size: contain;
     height: 45px;
     width: 300px;
 }
+.container-header {
+  border-top: 3px solid red;
+  background: #030303;
+  color: #f1f1f1;
+  padding-left: 17px;
+  margin-bottom: 4px;
+  height: 50px;
+}
+.container-header h4 {
+  margin-top: 4px;
+  margin-bottom: 3px;
+}
+.container-header a {
+  color: #0099d3;
+  text-decoration: none;
+  font-weight: bold;
+  margin-bottom: 4px;
+}
+.container-header a:hover,
+.container-header a:focus {
+  color: #00618a;
+  text-decoration: underline;
+}
+


### PR DESCRIPTION
Figured my two commits are based on your previous work so here's a PR...

Updated UserStore to take settings from either local storage or hash, removes any entry from the hash that's prefixed with `openshift_` and puts them into the user settings.

Supported entries so far that are used (same as before, just added the container name):
-  `openshift_container_name` - Used to set the container name text in the header
-  `openshift_back_url` - Used as the URL in the back link to get back to the main console
-  `openshift_auth_token` - The auth token, added a little band-aid to keep whatever auth code is there working as before until the auth code needs to go or needs further development.

And skinned the header similar to how the Java console in Openshift looks.
